### PR TITLE
Accessibility improvements for role on Table & Column components #1691

### DIFF
--- a/source/Table/Column.js
+++ b/source/Table/Column.js
@@ -74,6 +74,9 @@ export default class Column extends React.Component {
     /** Minimum width of column. */
     minWidth: PropTypes.number,
 
+    /** Optional role to apply to the column */
+    role: PropTypes.string,
+
     /** Optional inline style to apply to cell */
     style: PropTypes.object,
 
@@ -88,6 +91,7 @@ export default class Column extends React.Component {
     flexGrow: 0,
     flexShrink: 1,
     headerRenderer: defaultHeaderRenderer,
+    role: 'gridcell',
     style: {},
   };
 }

--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -50,6 +50,7 @@ describe('Table', () => {
     minWidth,
     defaultSortDirection,
     label,
+    flexibleCellProps, // @NOTE: Use flexibleCellProps to customize props sent to Column components
     ...flexTableProps
   } = {}) {
     return (
@@ -76,6 +77,7 @@ describe('Table', () => {
           style={columnStyle}
           headerStyle={columnHeaderStyle}
           id={columnID}
+          {...flexibleCellProps}
         />
         <Column
           label="Email"
@@ -83,6 +85,7 @@ describe('Table', () => {
           maxWidth={maxWidth}
           minWidth={minWidth}
           width={50}
+          {...flexibleCellProps}
         />
         {false}
         {true}
@@ -1243,9 +1246,14 @@ describe('Table', () => {
   });
 
   describe('a11y properties', () => {
-    it('should set aria role on the table', () => {
+    it('should set default aria role on the table', () => {
       const node = findDOMNode(render(getMarkup()));
       expect(node.getAttribute('role')).toEqual('grid');
+    });
+
+    it('should set aria role on the table based on props value', () => {
+      const node = findDOMNode(render(getMarkup({role: 'table'})));
+      expect(node.getAttribute('role')).toEqual('table');
     });
 
     it('should set aria col/row count on the table', () => {
@@ -1292,12 +1300,22 @@ describe('Table', () => {
       expect(rows[1].getAttribute('aria-rowindex')).toEqual('2');
     });
 
-    it('should set aria role on a cell', () => {
+    it('should set a default aria role on a cell', () => {
       const rendered = findDOMNode(render(getMarkup()));
       const cell = rendered.querySelector(
         '.ReactVirtualized__Table__rowColumn',
       );
       expect(cell.getAttribute('role')).toEqual('gridcell');
+    });
+
+    it('should set a customized aria role on a cell based on prop values', () => {
+      const rendered = findDOMNode(
+        render(getMarkup({flexibleCellProps: {role: 'cell'}})),
+      );
+      const cell = rendered.querySelector(
+        '.ReactVirtualized__Table__rowColumn',
+      );
+      expect(cell.getAttribute('role')).toEqual('cell');
     });
 
     it('should set aria colindex on a cell', () => {

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -223,6 +223,9 @@ export default class Table extends React.PureComponent {
     /** Table data is currently sorted in this direction (if it is sorted at all) */
     sortDirection: PropTypes.oneOf([SortDirection.ASC, SortDirection.DESC]),
 
+    /** Optional role to apply to the table */
+    role: PropTypes.string,
+
     /** Optional inline style */
     style: PropTypes.object,
 
@@ -245,6 +248,7 @@ export default class Table extends React.PureComponent {
     overscanRowCount: 10,
     rowRenderer: defaultRowRenderer,
     headerRowRenderer: defaultHeaderRowRenderer,
+    role: 'grid',
     rowStyle: {},
     scrollToAlignment: 'auto',
     scrollToIndex: -1,
@@ -368,6 +372,7 @@ export default class Table extends React.PureComponent {
       height,
       id,
       noRowsRenderer,
+      role,
       rowClassName,
       rowStyle,
       scrollToIndex,
@@ -410,7 +415,7 @@ export default class Table extends React.PureComponent {
         aria-rowcount={this.props.rowCount}
         className={clsx('ReactVirtualized__Table', className)}
         id={id}
-        role="grid"
+        role={role}
         style={style}>
         {!disableHeader &&
           headerRowRenderer({
@@ -460,6 +465,7 @@ export default class Table extends React.PureComponent {
       columnData,
       dataKey,
       id,
+      role,
     } = column.props;
 
     const cellData = cellDataGetter({columnData, dataKey, rowData});
@@ -492,7 +498,7 @@ export default class Table extends React.PureComponent {
         className={clsx('ReactVirtualized__Table__rowColumn', className)}
         key={'Row' + rowIndex + '-' + 'Col' + columnIndex}
         onClick={onClick}
-        role="gridcell"
+        role={role}
         style={style}
         title={title}>
         {renderedCell}


### PR DESCRIPTION
## Changes
We're seeing an issue that impacts multiple tables in our application. This is mostly on Windows computers and causes the screenreader to go into a different mode when tabbing into the `div` (this has role `"grid"` and the columns have role `"gridcell"`).

- On Windows, `role="grid"` triggers Application Mode for the Windows screenreader.
  - 90% of screenreader users are on Windows computers (importance of change)
  - Application mode passes all keystrokes to the browser
  - Visitors can no longer "read" the text as they're navigating the Table (which is effectively a grid).
- This does not seem to be an issue on Apple with Voiceover.

## Contribution Checklist

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ ] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [ ] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:

- Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
- Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
